### PR TITLE
add an interface for working with non-utf8 data

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -100,6 +100,7 @@ pub fn apply(base_image: &str, patch: &Patch<'_, str>) -> Result<String, ApplyEr
     Ok(image.into_iter().map(ImageLine::into_inner).collect())
 }
 
+/// Apply a non-utf8 `Patch` to a base image
 pub fn apply_bytes(base_image: &[u8], patch: &Patch<'_, [u8]>) -> Result<Vec<u8>, ApplyError> {
     let mut image: Vec<_> = LineIter::new(base_image)
         .map(ImageLine::Unpatched)

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -105,6 +105,7 @@ impl DiffOptions {
         Patch::new("original", "modified", hunks)
     }
 
+    /// Create a patch between two potentially non-utf8 texts
     pub fn create_patch_bytes<'a>(
         &self,
         original: &'a [u8],
@@ -184,6 +185,7 @@ pub fn create_patch<'a>(original: &'a str, modified: &'a str) -> Patch<'a, str> 
     DiffOptions::default().create_patch(original, modified)
 }
 
+/// Create a patch between two potentially non-utf8 texts
 pub fn create_patch_bytes<'a>(original: &'a [u8], modified: &'a [u8]) -> Patch<'a, [u8]> {
     DiffOptions::default().create_patch_bytes(original, modified)
 }

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -184,6 +184,10 @@ pub fn create_patch<'a>(original: &'a str, modified: &'a str) -> Patch<'a, str> 
     DiffOptions::default().create_patch(original, modified)
 }
 
+pub fn create_patch_bytes<'a>(original: &'a [u8], modified: &'a [u8]) -> Patch<'a, [u8]> {
+    DiffOptions::default().create_patch_bytes(original, modified)
+}
+
 fn to_hunks<'a, T: ?Sized>(
     lines1: &[&'a T],
     lines2: &[&'a T],

--- a/src/diff/tests.rs
+++ b/src/diff/tests.rs
@@ -326,14 +326,21 @@ fn test_compact() {
 macro_rules! assert_patch {
     ($diff_options:expr, $old:ident, $new:ident, $expected:ident $(,)?) => {
         let patch = $diff_options.create_patch($old, $new);
+        let bpatch = $diff_options.create_patch_bytes($old.as_bytes(), $new.as_bytes());
         let patch_str = patch.to_string();
-        let patch_bytes = patch.to_bytes();
+        let patch_bytes = bpatch.to_bytes();
         assert_eq!(patch_str, $expected);
         assert_eq!(patch_bytes, patch_str.as_bytes());
         assert_eq!(patch_bytes, $expected.as_bytes());
         assert_eq!(Patch::from_str($expected).unwrap(), patch);
         assert_eq!(Patch::from_str(&patch_str).unwrap(), patch);
+        assert_eq!(Patch::from_bytes($expected.as_bytes()).unwrap(), bpatch);
+        assert_eq!(Patch::from_bytes(&patch_bytes).unwrap(), bpatch);
         assert_eq!(apply($old, &patch).unwrap(), $new);
+        assert_eq!(
+            crate::apply_bytes($old.as_bytes(), &bpatch).unwrap(),
+            $new.as_bytes()
+        );
     };
     ($old:ident, $new:ident, $expected:ident $(,)?) => {
         assert_patch!(DiffOptions::default(), $old, $new, $expected);

--- a/src/diff/tests.rs
+++ b/src/diff/tests.rs
@@ -327,7 +327,10 @@ macro_rules! assert_patch {
     ($diff_options:expr, $old:ident, $new:ident, $expected:ident $(,)?) => {
         let patch = $diff_options.create_patch($old, $new);
         let patch_str = patch.to_string();
+        let patch_bytes = patch.to_bytes();
         assert_eq!(patch_str, $expected);
+        assert_eq!(patch_bytes, patch_str.as_bytes());
+        assert_eq!(patch_bytes, $expected.as_bytes());
         assert_eq!(Patch::from_str($expected).unwrap(), patch);
         assert_eq!(Patch::from_str(&patch_str).unwrap(), patch);
         assert_eq!(apply($old, &patch).unwrap(), $new);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ mod patch;
 mod range;
 mod utils;
 
-pub use apply::{apply, ApplyError};
+pub use apply::{apply, apply_bytes, ApplyError};
 pub use diff::{create_patch, DiffOptions};
 pub use merge::{merge, ConflictStyle, MergeOptions};
 pub use patch::{Hunk, HunkRange, Line, ParsePatchError, Patch, PatchFormatter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,6 @@ mod range;
 mod utils;
 
 pub use apply::{apply, apply_bytes, ApplyError};
-pub use diff::{create_patch, DiffOptions};
+pub use diff::{create_patch, create_patch_bytes, DiffOptions};
 pub use merge::{merge, merge_bytes, ConflictStyle, MergeOptions};
 pub use patch::{Hunk, HunkRange, Line, ParsePatchError, Patch, PatchFormatter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,13 @@
 //!
 //! The current diff implementation is based on the [Myers' diff algorithm].
 //!
+//! ## UTF-8 and Non-UTF-8
+//!
+//! This library has support for working with both utf8 and non-utf8 texts.
+//! Most of the API's have two different variants, one for working with utf8
+//! `str` texts (e.g. [`create_patch`]) and one for working with bytes `[u8]`
+//! which may or may not be utf8 (e.g. [`create_patch_bytes`]).
+//!
 //! ## Creating a Patch
 //!
 //! A [`Patch`] between two texts can be created by doing the following:
@@ -202,6 +209,8 @@
 //! [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
 //! [`Patch`]: struct.Patch.html
 //! [`PatchFormatter`]: struct.PatchFormatter.html
+//! [`create_patch`]: fn.create_patch.html
+//! [`create_patch_bytes`]: fn.create_patch_bytes.html
 
 mod apply;
 mod diff;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,5 +212,5 @@ mod utils;
 
 pub use apply::{apply, apply_bytes, ApplyError};
 pub use diff::{create_patch, DiffOptions};
-pub use merge::{merge, ConflictStyle, MergeOptions};
+pub use merge::{merge, merge_bytes, ConflictStyle, MergeOptions};
 pub use patch::{Hunk, HunkRange, Line, ParsePatchError, Patch, PatchFormatter};

--- a/src/merge/mod.rs
+++ b/src/merge/mod.rs
@@ -175,6 +175,7 @@ impl MergeOptions {
         )
     }
 
+    /// Perform a 3-way merge between potentially non-utf8 texts
     pub fn merge_bytes<'a>(
         &self,
         ancestor: &'a [u8],
@@ -267,6 +268,7 @@ pub fn merge<'a>(ancestor: &'a str, ours: &'a str, theirs: &'a str) -> Result<St
     MergeOptions::default().merge(ancestor, ours, theirs)
 }
 
+/// Perform a 3-way merge between potentially non-utf8 texts
 pub fn merge_bytes<'a>(
     ancestor: &'a [u8],
     ours: &'a [u8],

--- a/src/merge/mod.rs
+++ b/src/merge/mod.rs
@@ -263,9 +263,16 @@ impl Default for MergeOptions {
 ///
 /// assert_eq!(merge(original, a, b).unwrap(), expected);
 /// ```
-#[allow(dead_code)]
 pub fn merge<'a>(ancestor: &'a str, ours: &'a str, theirs: &'a str) -> Result<String, String> {
     MergeOptions::default().merge(ancestor, ours, theirs)
+}
+
+pub fn merge_bytes<'a>(
+    ancestor: &'a [u8],
+    ours: &'a [u8],
+    theirs: &'a [u8],
+) -> Result<Vec<u8>, Vec<u8>> {
+    MergeOptions::default().merge_bytes(ancestor, ours, theirs)
 }
 
 fn merge_solutions<'ancestor, 'ours, 'theirs, T: ?Sized + SliceLike>(

--- a/src/merge/tests.rs
+++ b/src/merge/tests.rs
@@ -18,6 +18,24 @@ macro_rules! assert_merge {
             result!($kind, $expected),
             solution
         );
+
+        let solution_bytes =
+            merge_bytes($original.as_bytes(), $ours.as_bytes(), $theirs.as_bytes());
+
+        macro_rules! result_bytes {
+            (Ok, $s:expr) => {
+                Result::<&[u8], &[u8]>::Ok($s.as_bytes())
+            };
+            (Err, $s:expr) => {
+                Result::<&[u8], &[u8]>::Err($s.as_bytes())
+            };
+        }
+        assert!(
+            same_merge_bytes(result_bytes!($kind, $expected), &solution_bytes),
+            concat!($msg, "\nexpected={:#?}\nactual={:#?}"),
+            result_bytes!($kind, $expected),
+            solution_bytes
+        );
     };
 }
 
@@ -25,6 +43,14 @@ fn same_merge(expected: Result<&str, &str>, actual: &Result<String, String>) -> 
     match (expected, actual) {
         (Ok(expected), Ok(actual)) => expected == actual,
         (Err(expected), Err(actual)) => expected == actual,
+        (_, _) => false,
+    }
+}
+
+fn same_merge_bytes(expected: Result<&[u8], &[u8]>, actual: &Result<Vec<u8>, Vec<u8>>) -> bool {
+    match (expected, actual) {
+        (Ok(expected), Ok(actual)) => expected == &actual[..],
+        (Err(expected), Err(actual)) => expected == &actual[..],
         (_, _) => false,
     }
 }

--- a/src/patch/format.rs
+++ b/src/patch/format.rs
@@ -37,15 +37,15 @@ impl PatchFormatter {
     }
 
     /// Returns a `Display` impl which can be used to print a Patch
-    pub fn fmt_patch<'a>(&'a self, patch: &'a Patch<'a>) -> impl Display + 'a {
+    pub fn fmt_patch<'a>(&'a self, patch: &'a Patch<'a, str>) -> impl Display + 'a {
         PatchDisplay { f: self, patch }
     }
 
-    fn fmt_hunk<'a>(&'a self, hunk: &'a Hunk<'a>) -> impl Display + 'a {
+    fn fmt_hunk<'a>(&'a self, hunk: &'a Hunk<'a, str>) -> impl Display + 'a {
         HunkDisplay { f: self, hunk }
     }
 
-    fn fmt_line<'a>(&'a self, line: &'a Line<'a>) -> impl Display + 'a {
+    fn fmt_line<'a>(&'a self, line: &'a Line<'a, str>) -> impl Display + 'a {
         LineDisplay { f: self, line }
     }
 }
@@ -58,7 +58,7 @@ impl Default for PatchFormatter {
 
 struct PatchDisplay<'a> {
     f: &'a PatchFormatter,
-    patch: &'a Patch<'a>,
+    patch: &'a Patch<'a, str>,
 }
 
 impl Display for PatchDisplay<'_> {
@@ -82,7 +82,7 @@ impl Display for PatchDisplay<'_> {
 
 struct HunkDisplay<'a> {
     f: &'a PatchFormatter,
-    hunk: &'a Hunk<'a>,
+    hunk: &'a Hunk<'a, str>,
 }
 
 impl Display for HunkDisplay<'_> {
@@ -117,7 +117,7 @@ impl Display for HunkDisplay<'_> {
 
 struct LineDisplay<'a> {
     f: &'a PatchFormatter,
-    line: &'a Line<'a>,
+    line: &'a Line<'a, str>,
 }
 
 impl Display for LineDisplay<'_> {

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -46,6 +46,10 @@ impl<'a, T: ToOwned + ?Sized> Patch<'a, T> {
 }
 
 impl<T: AsRef<[u8]> + ToOwned + ?Sized> Patch<'_, T> {
+    /// Convert a `Patch` into bytes
+    ///
+    /// This is the equivalent of the `to_string` function but for
+    /// potentially non-utf8 patches.
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
         PatchFormatter::new()
@@ -82,6 +86,7 @@ impl<'a> Patch<'a, str> {
 }
 
 impl<'a> Patch<'a, [u8]> {
+    /// Parse a `Patch` from bytes
     pub fn from_bytes(s: &'a [u8]) -> Result<Patch<'a, [u8]>, ParsePatchError> {
         parse::parse_bytes(s)
     }

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -81,6 +81,12 @@ impl<'a> Patch<'a, str> {
     }
 }
 
+impl<'a> Patch<'a, [u8]> {
+    pub fn from_bytes(s: &'a [u8]) -> Result<Patch<'a, [u8]>, ParsePatchError> {
+        parse::parse_bytes(s)
+    }
+}
+
 impl<T: ToOwned + ?Sized> Clone for Patch<'_, T> {
     fn clone(&self) -> Self {
         Self {

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -1,6 +1,6 @@
 //! Parse a Patch
 
-use super::{Filename, Hunk, HunkRange, Line, NO_NEWLINE_AT_EOF};
+use super::{Hunk, HunkRange, Line, ESCAPED_CHARS, NO_NEWLINE_AT_EOF};
 use crate::{patch::Patch, utils::LineIter};
 use std::{borrow::Cow, fmt};
 
@@ -101,7 +101,7 @@ fn is_quoted(s: &str) -> bool {
 }
 
 fn unescaped_filename<'a>(filename: &'a str) -> Result<Cow<'a, str>> {
-    if filename.contains(Filename::ESCAPED_CHARS) {
+    if filename.contains(ESCAPED_CHARS) {
         return Err(ParsePatchError::new("invalid char in unquoted filename"));
     }
 
@@ -121,7 +121,7 @@ fn escaped_filename(escaped: &str) -> Result<Cow<'_, str>> {
                 'n' | 't' | '0' | 'r' | '\"' | '\\' => filename.push(c),
                 _ => return Err(ParsePatchError::new("invalid escaped character")),
             }
-        } else if Filename::ESCAPED_CHARS.contains(&c) {
+        } else if ESCAPED_CHARS.contains(&c) {
             return Err(ParsePatchError::new("invalid unescaped character"));
         } else {
             filename.push(c);

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -28,7 +28,7 @@ impl fmt::Display for ParsePatchError {
 impl std::error::Error for ParsePatchError {}
 
 struct Parser<'a> {
-    lines: std::iter::Peekable<LineIter<'a>>,
+    lines: std::iter::Peekable<LineIter<'a, str>>,
 }
 
 impl<'a> Parser<'a> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,16 +1,18 @@
 //! Common utilities
 
-use std::collections::{hash_map::Entry, HashMap};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    hash::Hash,
+};
 
 /// Classifies lines, converting lines into unique `u64`s for quicker comparison
-#[derive(Default)]
-pub struct Classifier<'a> {
+pub struct Classifier<'a, T: ?Sized> {
     next_id: u64,
-    unique_ids: HashMap<&'a str, u64>,
+    unique_ids: HashMap<&'a T, u64>,
 }
 
-impl<'a> Classifier<'a> {
-    fn classify(&mut self, record: &'a str) -> u64 {
+impl<'a, T: ?Sized + Eq + Hash> Classifier<'a, T> {
+    fn classify(&mut self, record: &'a T) -> u64 {
         match self.unique_ids.entry(record) {
             Entry::Occupied(o) => *o.get(),
             Entry::Vacant(v) => {
@@ -20,32 +22,43 @@ impl<'a> Classifier<'a> {
             }
         }
     }
+}
 
-    pub fn classify_lines(&mut self, text: &'a str) -> (Vec<&'a str>, Vec<u64>) {
+impl<'a, T: ?Sized + Text> Classifier<'a, T> {
+    pub fn classify_lines(&mut self, text: &'a T) -> (Vec<&'a T>, Vec<u64>) {
         LineIter::new(text)
             .map(|line| (line, self.classify(&line)))
             .unzip()
     }
 }
 
-/// Iterator over the lines of a string, including the `\n` character.
-pub struct LineIter<'a>(&'a str);
+impl<T: ?Sized> Default for Classifier<'_, T> {
+    fn default() -> Self {
+        Self {
+            next_id: 0,
+            unique_ids: HashMap::default(),
+        }
+    }
+}
 
-impl<'a> LineIter<'a> {
-    pub fn new(text: &'a str) -> Self {
+/// Iterator over the lines of a string, including the `\n` character.
+pub struct LineIter<'a, T: ?Sized>(&'a T);
+
+impl<'a, T: ?Sized> LineIter<'a, T> {
+    pub fn new(text: &'a T) -> Self {
         Self(text)
     }
 }
 
-impl<'a> Iterator for LineIter<'a> {
-    type Item = &'a str;
+impl<'a, T: Text + ?Sized> Iterator for LineIter<'a, T> {
+    type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.0.is_empty() {
             return None;
         }
 
-        let end = if let Some(idx) = self.0.find('\n') {
+        let end = if let Some(idx) = self.0.find("\n") {
             idx + 1
         } else {
             self.0.len()
@@ -55,4 +68,183 @@ impl<'a> Iterator for LineIter<'a> {
         self.0 = remaining;
         Some(line)
     }
+}
+
+/// A helper trait for processing text like `str` and `[u8]`
+/// Useful for abstracting over those types for parsing as well as breaking input into lines
+pub trait Text: Eq + Hash {
+    fn is_empty(&self) -> bool;
+    fn len(&self) -> usize;
+    fn starts_with(&self, prefix: &str) -> bool;
+    fn ends_with(&self, suffix: &str) -> bool;
+    fn strip_prefix(&self, prefix: &str) -> Option<&Self>;
+    fn strip_suffix(&self, suffix: &str) -> Option<&Self>;
+    fn split_at_exclusive(&self, needle: &str) -> Option<(&Self, &Self)>;
+    fn find(&self, needle: &str) -> Option<usize>;
+    fn split_at(&self, mid: usize) -> (&Self, &Self);
+    fn as_str(&self) -> Option<&str>;
+    fn as_bytes(&self) -> &[u8];
+    fn lines(&self) -> LineIter<Self>;
+
+    fn parse<T: std::str::FromStr>(&self) -> Option<T> {
+        self.as_str().and_then(|s| s.parse().ok())
+    }
+}
+
+impl Text for str {
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn starts_with(&self, prefix: &str) -> bool {
+        self.starts_with(prefix)
+    }
+
+    fn ends_with(&self, suffix: &str) -> bool {
+        self.ends_with(suffix)
+    }
+
+    fn strip_prefix(&self, prefix: &str) -> Option<&Self> {
+        if self.starts_with(prefix) {
+            Some(&self[prefix.len()..])
+        } else {
+            None
+        }
+    }
+
+    fn strip_suffix(&self, suffix: &str) -> Option<&Self> {
+        if self.ends_with(suffix) {
+            Some(&self[..self.len() - suffix.len()])
+        } else {
+            None
+        }
+    }
+
+    fn split_at_exclusive(&self, needle: &str) -> Option<(&Self, &Self)> {
+        if let Some(idx) = self.find(needle) {
+            Some((&self[..idx], &self[idx + needle.len()..]))
+        } else {
+            None
+        }
+    }
+
+    fn find(&self, needle: &str) -> Option<usize> {
+        self.find(needle)
+    }
+
+    fn split_at(&self, mid: usize) -> (&Self, &Self) {
+        self.split_at(mid)
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        Some(self)
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
+
+    fn lines(&self) -> LineIter<Self> {
+        LineIter::new(self)
+    }
+}
+
+impl Text for [u8] {
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn starts_with(&self, prefix: &str) -> bool {
+        self.starts_with(prefix.as_bytes())
+    }
+
+    fn ends_with(&self, suffix: &str) -> bool {
+        self.ends_with(suffix.as_bytes())
+    }
+
+    fn strip_prefix(&self, prefix: &str) -> Option<&Self> {
+        if self.starts_with(prefix.as_bytes()) {
+            Some(&self[prefix.len()..])
+        } else {
+            None
+        }
+    }
+
+    fn strip_suffix(&self, suffix: &str) -> Option<&Self> {
+        if self.ends_with(suffix.as_bytes()) {
+            Some(&self[..self.len() - suffix.len()])
+        } else {
+            None
+        }
+    }
+
+    fn split_at_exclusive(&self, needle: &str) -> Option<(&Self, &Self)> {
+        if let Some(idx) = find_bytes(self, needle.as_bytes()) {
+            Some((&self[..idx], &self[idx + needle.len()..]))
+        } else {
+            None
+        }
+    }
+
+    fn find(&self, needle: &str) -> Option<usize> {
+        find_bytes(self, needle.as_bytes())
+    }
+
+    fn split_at(&self, mid: usize) -> (&Self, &Self) {
+        self.split_at(mid)
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        std::str::from_utf8(self).ok()
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self
+    }
+
+    fn lines(&self) -> LineIter<Self> {
+        LineIter::new(self)
+    }
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    match needle.len() {
+        0 => Some(0),
+        1 => find_byte(haystack, needle[0]),
+        len if len > haystack.len() => None,
+        needle_len => {
+            let mut offset = 0;
+            let mut haystack = haystack;
+
+            while let Some(position) = find_byte(haystack, needle[0]) {
+                offset += position;
+
+                if let Some(haystack) = haystack.get(position..position + needle_len) {
+                    if haystack == needle {
+                        return Some(offset);
+                    }
+                } else {
+                    return None;
+                }
+
+                haystack = &haystack[position + 1..];
+                offset += 1;
+            }
+
+            None
+        }
+    }
+}
+
+// XXX Maybe use `memchr`?
+fn find_byte(haystack: &[u8], byte: u8) -> Option<usize> {
+    haystack.iter().position(|&b| b == byte)
 }


### PR DESCRIPTION
This PR adds support for working with potentially non-utf8 data by:
* Making the `Patch` struct generic over both `str` for utf8 data and `[u8]` for potentially non-utf8 data.
* Adding `_bytes` variants to the various apis for working with non-utf8 data
* Adding support to the `PatchFormatter` to be able to write non-utf8 patches into `T: io::Write`

Closes: #1 