### PR TITLE
Additional api

### DIFF
--- a/src/diff/tests.rs
+++ b/src/diff/tests.rs
@@ -3,6 +3,7 @@ use crate::{
     apply::apply,
     diff::{Diff, DiffRange},
     patch::Patch,
+    PatchFormatter,
     range::Range,
 };
 
@@ -516,6 +517,35 @@ fn no_newline_at_eof() {
 \\ No newline at end of file
 ";
     assert_patch!(old, new, expected);
+}
+
+#[test]
+fn without_no_newline_at_eof() {
+    let old = "old line";
+    let new = "new line";
+    let expected = "\
+--- original
++++ modified
+@@ -1 +1 @@
+-old line
++new line
+";
+
+    let f = PatchFormatter::new().without_missing_newline_message();
+    let patch = create_patch(old, new);
+    let bpatch = create_patch_bytes(old.as_bytes(), new.as_bytes());
+    let patch_str = format!("{}", f.fmt_patch(&patch));
+    let mut patch_bytes = Vec::new();
+    f.write_patch_into(&bpatch, &mut patch_bytes).unwrap();
+
+    assert_eq!(patch_str, expected);
+    assert_eq!(patch_bytes, patch_str.as_bytes());
+    assert_eq!(patch_bytes, expected.as_bytes());
+    assert_eq!(apply(old, &patch).unwrap(), new);
+    assert_eq!(
+        crate::apply_bytes(old.as_bytes(), &bpatch).unwrap(),
+        new.as_bytes()
+    );
 }
 
 #[test]

--- a/src/diff/tests.rs
+++ b/src/diff/tests.rs
@@ -464,6 +464,27 @@ The door of all subtleties!
 ";
     opts.set_context_len(1);
     assert_patch!(opts, lao, tzu, expected);
+
+    let expected = "\
+--- from
++++ to
+@@ -1,5 +1,4 @@
+-The Way that can be told of is not the eternal Way;
+-The name that can be named is not the eternal name.
+ The Nameless is the origin of Heaven and Earth;
+-The Named is the mother of all things.
++The named is the mother of all things.
++
+ Therefore let there always be non-being,
+@@ -11 +10,4 @@
+   they have different names.
++They both may be called deep and profound.
++Deeper and more profound,
++The door of all subtleties!
+";
+    opts.set_original("from");
+    opts.set_modified("to");
+    assert_patch!(opts, lao, tzu, expected);
 }
 
 #[test]

--- a/src/patch/format.rs
+++ b/src/patch/format.rs
@@ -9,6 +9,7 @@ use std::{
 #[derive(Debug)]
 pub struct PatchFormatter {
     with_color: bool,
+    without_missing_newline_message: bool,
 
     context: Style,
     delete: Style,
@@ -23,6 +24,7 @@ impl PatchFormatter {
     pub fn new() -> Self {
         Self {
             with_color: false,
+            without_missing_newline_message: false,
 
             context: Style::new(),
             delete: Color::Red.normal(),
@@ -36,6 +38,12 @@ impl PatchFormatter {
     /// Enable formatting a patch with color
     pub fn with_color(mut self) -> Self {
         self.with_color = true;
+        self
+    }
+
+    /// Enable formatting a patch without a "No newline at end of file" message
+    pub fn without_missing_newline_message(mut self) -> Self {
+        self.without_missing_newline_message = true;
         self
     }
 
@@ -238,7 +246,9 @@ impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
 
         if !line.ends_with(b"\n") {
             writeln!(w)?;
-            writeln!(w, "{}", NO_NEWLINE_AT_EOF)?;
+            if !self.f.without_missing_newline_message {
+                writeln!(w, "{}", NO_NEWLINE_AT_EOF)?;
+            }
         }
 
         Ok(())
@@ -269,7 +279,9 @@ impl Display for LineDisplay<'_, str> {
 
         if !line.ends_with('\n') {
             writeln!(f)?;
-            writeln!(f, "{}", NO_NEWLINE_AT_EOF)?;
+            if !self.f.without_missing_newline_message {
+                writeln!(f, "{}", NO_NEWLINE_AT_EOF)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Hi,

First of all, thanks a lot for writing diffy.  I appreciate this this tool a lot!

I started using it and I miss the ability to specify the original and modified filename, and the ability to avoid outputting the "\ No newline at end of file" message, so here are two patches for that.

Note that I chose to add custom code rather than using the assert_patch! macro for the newline patch.  Constructing a Patch from the representation obviously leads to a different content and it didn't seem worth the trouble to complicate the macro to handle a PatchFormatter and skip those tests when the option is set.  I'm also not entirely happy with the `without_missing_newline_message` name, but didn't find anything better.

For the custom file names, I didn't do anything with the `MergeOptions` as mentioned in your original issue, as it wasn't clear to me how file names would interact there.

Let me know if there's any problem with those patches or if you'd like any change!