### PR TITLE
Replace unmaintained ansi_term crate usage with nu_ansi_term which seems to be maintained

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["text-processing"]
 edition = "2018"
 
 [dependencies]
-ansi_term = "0.12"
+nu-ansi-term = "0.46.0"

--- a/src/patch/format.rs
+++ b/src/patch/format.rs
@@ -1,5 +1,5 @@
 use super::{Hunk, Line, Patch, NO_NEWLINE_AT_EOF};
-use ansi_term::{Color, Style};
+use nu_ansi_term::{Color, Style};
 use std::{
     fmt::{Display, Formatter, Result},
     io,


### PR DESCRIPTION
I've choose `nu_ansi_term` as alternative implementation as they seem to offer the "same" API, so it's just a matter of changing the dependency. I would appreciate a new release containing this fix to solve https://github.com/diesel-rs/diesel/issues/3286

Addresses https://rustsec.org/advisories/RUSTSEC-2021-0139