### PR TITLE
Chore: upgraded nu-ansi-term

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["text-processing"]
 edition = "2018"
 
 [dependencies]
-nu-ansi-term = "0.46.0"
+nu-ansi-term = "0.47"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["text-processing"]
 edition = "2018"
 
 [dependencies]
-nu-ansi-term = "0.47"
+nu-ansi-term = "0.50"


### PR DESCRIPTION
This removes `winapi` (in favour of the better maintained `windows-sys`) in the dependency graph