### PR TITLE
feat: control filenames in DiffOptions

### DIFF
--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -144,6 +144,7 @@ where
 struct Filename<'a, T: ToOwned + ?Sized>(Cow<'a, T>);
 
 const ESCAPED_CHARS: &[char] = &['\n', '\t', '\0', '\r', '\"', '\\'];
+#[allow(clippy::byte_char_slices)]
 const ESCAPED_CHARS_BYTES: &[u8] = &[b'\n', b'\t', b'\0', b'\r', b'\"', b'\\'];
 
 impl Filename<'_, str> {


### PR DESCRIPTION
I'm using diffy to format output in a test running, to make it easier to find where our actual output differed from the expected output. As a small quality of life improvement, it'd be nice if the diffs said "expected" and "actual" rather than "original" and "modified".

This PR adds options to `DiffOptions` to be able to explicitly set the filenames.