### PR TITLE
chore: Debug line when unable to parse

### DIFF
--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -319,7 +319,10 @@ fn hunk_lines<'a, T: Text + ?Sized>(parser: &mut Parser<'a, T>) -> Result<Vec<Li
                 }
             }
         } else {
-            return Err(ParsePatchError::new("unexpected line in hunk body"));
+            return Err(ParsePatchError::new(format!(
+                "unexpected line in hunk body: '{}'",
+                line.as_str().unwrap_or("EMPTY")
+            )));
         };
 
         lines.push(line);


### PR DESCRIPTION
Hey there,

I'm doing some editing with AI generated patches, and had a hard time figuring out what line was causing the issue (turns out it was the leading space). Simple change so the issue is visible.