### PR TITLE
fix(patch): on non-UTF8 filename, error rather than panic 

### DIFF
--- a/src/patch/error.rs
+++ b/src/patch/error.rs
@@ -110,6 +110,9 @@ pub(crate) enum ParsePatchErrorKind {
 
     /// Orphaned hunk header found after trailing content.
     OrphanedHunkHeader,
+
+    /// Filename contains invalid UTF-8 when parsing as text.
+    InvalidUtf8Path,
 }
 
 impl fmt::Display for ParsePatchErrorKind {
@@ -136,6 +139,7 @@ impl fmt::Display for ParsePatchErrorKind {
             Self::UnexpectedHunkLine => "unexpected line in hunk body",
             Self::MissingNewline => "missing newline",
             Self::OrphanedHunkHeader => "orphaned hunk header after trailing content",
+            Self::InvalidUtf8Path => "filename is not valid UTF-8",
         };
         write!(f, "{msg}")
     }

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -12,6 +12,31 @@ use std::borrow::Cow;
 
 type Result<T, E = ParsePatchError> = std::result::Result<T, E>;
 
+/// Options that control parsing behavior.
+///
+/// Defaults match the [`parse`]/[`parse_bytes`] behavior.
+#[derive(Clone, Copy)]
+pub(crate) struct ParseOpts {
+    reject_orphaned_hunks: bool,
+}
+
+impl Default for ParseOpts {
+    fn default() -> Self {
+        Self {
+            reject_orphaned_hunks: false,
+        }
+    }
+}
+
+impl ParseOpts {
+    /// Reject orphaned `@@ ` hunk headers after parsed hunks,
+    /// matching `git apply` behavior.
+    pub(crate) fn reject_orphaned_hunks(mut self) -> Self {
+        self.reject_orphaned_hunks = true;
+        self
+    }
+}
+
 struct Parser<'a, T: Text + ?Sized> {
     lines: std::iter::Peekable<LineIter<'a, T>>,
     offset: usize,
@@ -54,7 +79,7 @@ impl<'a, T: Text + ?Sized> Parser<'a, T> {
 }
 
 pub fn parse(input: &str) -> Result<Patch<'_, str>> {
-    let (result, _consumed) = parse_one(input);
+    let (result, _consumed) = parse_one(input, ParseOpts::default());
     result
 }
 
@@ -62,7 +87,7 @@ pub fn parse(input: &str) -> Result<Patch<'_, str>> {
 ///
 /// Always returns consumed bytes alongside the result
 /// so callers can advance past the parsed or partially parsed content.
-pub(crate) fn parse_one(input: &str) -> (Result<Patch<'_, str>>, usize) {
+pub(crate) fn parse_one(input: &str, opts: ParseOpts) -> (Result<Patch<'_, str>>, usize) {
     let mut parser = Parser::new(input);
 
     let header = match patch_header(&mut parser) {
@@ -73,6 +98,11 @@ pub(crate) fn parse_one(input: &str) -> (Result<Patch<'_, str>>, usize) {
         Ok(h) => h,
         Err(e) => return (Err(e), parser.offset()),
     };
+    if opts.reject_orphaned_hunks {
+        if let Err(e) = reject_orphaned_hunk_headers(&mut parser) {
+            return (Err(e), parser.offset());
+        }
+    }
 
     let original = match header.0.map(convert_cow_to_str).transpose() {
         Ok(o) => o,
@@ -87,16 +117,8 @@ pub(crate) fn parse_one(input: &str) -> (Result<Patch<'_, str>>, usize) {
 }
 
 pub fn parse_strict(input: &str) -> Result<Patch<'_, str>> {
-    let mut parser = Parser::new(input);
-    let header = patch_header(&mut parser)?;
-    let hunks = hunks(&mut parser)?;
-    reject_orphaned_hunk_headers(&mut parser)?;
-
-    Ok(Patch::new(
-        header.0.map(convert_cow_to_str),
-        header.1.map(convert_cow_to_str),
-        hunks,
-    ))
+    let (result, _consumed) = parse_one(input, ParseOpts::default().reject_orphaned_hunks());
+    result
 }
 
 pub fn parse_bytes(input: &[u8]) -> Result<Patch<'_, [u8]>> {

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -106,12 +106,12 @@ pub fn parse_strict(input: &str) -> Result<Patch<'_, str>> {
 }
 
 pub fn parse_bytes(input: &[u8]) -> Result<Patch<'_, [u8]>> {
-    let (result, _consumed) = parse_bytes_one(input, ParseOpts::default());
+    let (result, _consumed) = parse_one(input, ParseOpts::default());
     result
 }
 
 pub fn parse_bytes_strict(input: &[u8]) -> Result<Patch<'_, [u8]>> {
-    let (result, _consumed) = parse_bytes_one(input, ParseOpts::default().reject_orphaned_hunks());
+    let (result, _consumed) = parse_one(input, ParseOpts::default().reject_orphaned_hunks());
     result
 }
 
@@ -119,37 +119,10 @@ pub fn parse_bytes_strict(input: &[u8]) -> Result<Patch<'_, [u8]>> {
 ///
 /// Always returns consumed bytes alongside the result
 /// so callers can advance past the parsed or partially parsed content.
-pub(crate) fn parse_one(input: &str, opts: ParseOpts) -> (Result<Patch<'_, str>>, usize) {
-    let mut parser = Parser::new(input);
-
-    let header = match patch_header(&mut parser, &opts) {
-        Ok(h) => h,
-        Err(e) => return (Err(e), parser.offset()),
-    };
-    let hunks = match hunks(&mut parser) {
-        Ok(h) => h,
-        Err(e) => return (Err(e), parser.offset()),
-    };
-    if opts.reject_orphaned_hunks {
-        if let Err(e) = reject_orphaned_hunk_headers(&mut parser) {
-            return (Err(e), parser.offset());
-        }
-    }
-
-    let original = match header.0.map(convert_cow_to_str).transpose() {
-        Ok(o) => o,
-        Err(e) => return (Err(e), parser.offset()),
-    };
-    let modified = match header.1.map(convert_cow_to_str).transpose() {
-        Ok(m) => m,
-        Err(e) => return (Err(e), parser.offset()),
-    };
-
-    (Ok(Patch::new(original, modified, hunks)), parser.offset())
-}
-
-/// Like [`parse_one`] but for bytes.
-pub(crate) fn parse_bytes_one(input: &[u8], opts: ParseOpts) -> (Result<Patch<'_, [u8]>>, usize) {
+pub(crate) fn parse_one<T: Text + ?Sized>(
+    input: &T,
+    opts: ParseOpts,
+) -> (Result<Patch<'_, T>>, usize) {
     let mut parser = Parser::new(input);
 
     let header = match patch_header(&mut parser, &opts) {
@@ -169,23 +142,11 @@ pub(crate) fn parse_bytes_one(input: &[u8], opts: ParseOpts) -> (Result<Patch<'_
     (Ok(Patch::new(header.0, header.1, hunks)), parser.offset())
 }
 
-// This is only used when the type originated as a utf8 string
-fn convert_cow_to_str(cow: Cow<'_, [u8]>) -> Result<Cow<'_, str>> {
-    match cow {
-        Cow::Borrowed(b) => std::str::from_utf8(b)
-            .map(Cow::Borrowed)
-            .map_err(|_| ParsePatchErrorKind::InvalidUtf8Path.into()),
-        Cow::Owned(o) => String::from_utf8(o)
-            .map(Cow::Owned)
-            .map_err(|_| ParsePatchErrorKind::InvalidUtf8Path.into()),
-    }
-}
-
 #[allow(clippy::type_complexity)]
-fn patch_header<'a, T: Text + ToOwned + ?Sized>(
+fn patch_header<'a, T: Text + ?Sized>(
     parser: &mut Parser<'a, T>,
     opts: &ParseOpts,
-) -> Result<(Option<Cow<'a, [u8]>>, Option<Cow<'a, [u8]>>)> {
+) -> Result<(Option<Cow<'a, T>>, Option<Cow<'a, T>>)> {
     if opts.skip_preamble {
         skip_header_preamble(parser)?;
     }
@@ -225,10 +186,7 @@ fn skip_header_preamble<T: Text + ?Sized>(parser: &mut Parser<'_, T>) -> Result<
     Ok(())
 }
 
-fn parse_filename<'a, T: Text + ToOwned + ?Sized>(
-    prefix: &str,
-    line: &'a T,
-) -> Result<Cow<'a, [u8]>> {
+fn parse_filename<'a, T: Text + ?Sized>(prefix: &str, line: &'a T) -> Result<Cow<'a, T>> {
     let line = line
         .strip_prefix(prefix)
         .ok_or(ParsePatchErrorKind::InvalidFilename)?;

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -95,6 +95,28 @@ pub fn parse(input: &str) -> Result<Patch<'_, str>> {
     result
 }
 
+pub fn parse_strict(input: &str) -> Result<Patch<'_, str>> {
+    let (result, _consumed) = parse_one(input, ParseOpts::default().reject_orphaned_hunks());
+    result
+}
+
+pub fn parse_bytes(input: &[u8]) -> Result<Patch<'_, [u8]>> {
+    let mut parser = Parser::new(input);
+    let header = patch_header(&mut parser, &ParseOpts::default())?;
+    let hunks = hunks(&mut parser)?;
+
+    Ok(Patch::new(header.0, header.1, hunks))
+}
+
+pub fn parse_bytes_strict(input: &[u8]) -> Result<Patch<'_, [u8]>> {
+    let mut parser = Parser::new(input);
+    let header = patch_header(&mut parser, &ParseOpts::default())?;
+    let hunks = hunks(&mut parser)?;
+    reject_orphaned_hunk_headers(&mut parser)?;
+
+    Ok(Patch::new(header.0, header.1, hunks))
+}
+
 /// Parses one patch from input.
 ///
 /// Always returns consumed bytes alongside the result
@@ -126,28 +148,6 @@ pub(crate) fn parse_one(input: &str, opts: ParseOpts) -> (Result<Patch<'_, str>>
     };
 
     (Ok(Patch::new(original, modified, hunks)), parser.offset())
-}
-
-pub fn parse_strict(input: &str) -> Result<Patch<'_, str>> {
-    let (result, _consumed) = parse_one(input, ParseOpts::default().reject_orphaned_hunks());
-    result
-}
-
-pub fn parse_bytes(input: &[u8]) -> Result<Patch<'_, [u8]>> {
-    let mut parser = Parser::new(input);
-    let header = patch_header(&mut parser, &ParseOpts::default())?;
-    let hunks = hunks(&mut parser)?;
-
-    Ok(Patch::new(header.0, header.1, hunks))
-}
-
-pub fn parse_bytes_strict(input: &[u8]) -> Result<Patch<'_, [u8]>> {
-    let mut parser = Parser::new(input);
-    let header = patch_header(&mut parser, &ParseOpts::default())?;
-    let hunks = hunks(&mut parser)?;
-    reject_orphaned_hunk_headers(&mut parser)?;
-
-    Ok(Patch::new(header.0, header.1, hunks))
 }
 
 // This is only used when the type originated as a utf8 string

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -101,20 +101,13 @@ pub fn parse_strict(input: &str) -> Result<Patch<'_, str>> {
 }
 
 pub fn parse_bytes(input: &[u8]) -> Result<Patch<'_, [u8]>> {
-    let mut parser = Parser::new(input);
-    let header = patch_header(&mut parser, &ParseOpts::default())?;
-    let hunks = hunks(&mut parser)?;
-
-    Ok(Patch::new(header.0, header.1, hunks))
+    let (result, _consumed) = parse_bytes_one(input, ParseOpts::default());
+    result
 }
 
 pub fn parse_bytes_strict(input: &[u8]) -> Result<Patch<'_, [u8]>> {
-    let mut parser = Parser::new(input);
-    let header = patch_header(&mut parser, &ParseOpts::default())?;
-    let hunks = hunks(&mut parser)?;
-    reject_orphaned_hunk_headers(&mut parser)?;
-
-    Ok(Patch::new(header.0, header.1, hunks))
+    let (result, _consumed) = parse_bytes_one(input, ParseOpts::default().reject_orphaned_hunks());
+    result
 }
 
 /// Parses one patch from input.
@@ -148,6 +141,27 @@ pub(crate) fn parse_one(input: &str, opts: ParseOpts) -> (Result<Patch<'_, str>>
     };
 
     (Ok(Patch::new(original, modified, hunks)), parser.offset())
+}
+
+/// Like [`parse_one`] but for bytes.
+pub(crate) fn parse_bytes_one(input: &[u8], opts: ParseOpts) -> (Result<Patch<'_, [u8]>>, usize) {
+    let mut parser = Parser::new(input);
+
+    let header = match patch_header(&mut parser, &opts) {
+        Ok(h) => h,
+        Err(e) => return (Err(e), parser.offset()),
+    };
+    let hunks = match hunks(&mut parser) {
+        Ok(h) => h,
+        Err(e) => return (Err(e), parser.offset()),
+    };
+    if opts.reject_orphaned_hunks {
+        if let Err(e) = reject_orphaned_hunk_headers(&mut parser) {
+            return (Err(e), parser.offset());
+        }
+    }
+
+    (Ok(Patch::new(header.0, header.1, hunks)), parser.offset())
 }
 
 // This is only used when the type originated as a utf8 string

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -17,18 +17,30 @@ type Result<T, E = ParsePatchError> = std::result::Result<T, E>;
 /// Defaults match the [`parse`]/[`parse_bytes`] behavior.
 #[derive(Clone, Copy)]
 pub(crate) struct ParseOpts {
+    skip_preamble: bool,
     reject_orphaned_hunks: bool,
 }
 
 impl Default for ParseOpts {
     fn default() -> Self {
         Self {
+            skip_preamble: true,
             reject_orphaned_hunks: false,
         }
     }
 }
 
 impl ParseOpts {
+    /// Don't skip preamble lines before `---`/`+++`/`@@`.
+    ///
+    /// Useful when the caller has already positioned the input
+    /// at the start of the patch content.
+    #[allow(dead_code)] // will be used by patch_set parser
+    pub(crate) fn no_skip_preamble(mut self) -> Self {
+        self.skip_preamble = false;
+        self
+    }
+
     /// Reject orphaned `@@ ` hunk headers after parsed hunks,
     /// matching `git apply` behavior.
     pub(crate) fn reject_orphaned_hunks(mut self) -> Self {
@@ -90,7 +102,7 @@ pub fn parse(input: &str) -> Result<Patch<'_, str>> {
 pub(crate) fn parse_one(input: &str, opts: ParseOpts) -> (Result<Patch<'_, str>>, usize) {
     let mut parser = Parser::new(input);
 
-    let header = match patch_header(&mut parser) {
+    let header = match patch_header(&mut parser, &opts) {
         Ok(h) => h,
         Err(e) => return (Err(e), parser.offset()),
     };
@@ -123,7 +135,7 @@ pub fn parse_strict(input: &str) -> Result<Patch<'_, str>> {
 
 pub fn parse_bytes(input: &[u8]) -> Result<Patch<'_, [u8]>> {
     let mut parser = Parser::new(input);
-    let header = patch_header(&mut parser)?;
+    let header = patch_header(&mut parser, &ParseOpts::default())?;
     let hunks = hunks(&mut parser)?;
 
     Ok(Patch::new(header.0, header.1, hunks))
@@ -131,7 +143,7 @@ pub fn parse_bytes(input: &[u8]) -> Result<Patch<'_, [u8]>> {
 
 pub fn parse_bytes_strict(input: &[u8]) -> Result<Patch<'_, [u8]>> {
     let mut parser = Parser::new(input);
-    let header = patch_header(&mut parser)?;
+    let header = patch_header(&mut parser, &ParseOpts::default())?;
     let hunks = hunks(&mut parser)?;
     reject_orphaned_hunk_headers(&mut parser)?;
 
@@ -153,8 +165,11 @@ fn convert_cow_to_str(cow: Cow<'_, [u8]>) -> Result<Cow<'_, str>> {
 #[allow(clippy::type_complexity)]
 fn patch_header<'a, T: Text + ToOwned + ?Sized>(
     parser: &mut Parser<'a, T>,
+    opts: &ParseOpts,
 ) -> Result<(Option<Cow<'a, [u8]>>, Option<Cow<'a, [u8]>>)> {
-    skip_header_preamble(parser)?;
+    if opts.skip_preamble {
+        skip_header_preamble(parser)?;
+    }
 
     let mut filename1 = None;
     let mut filename2 = None;

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -74,12 +74,16 @@ pub(crate) fn parse_one(input: &str) -> (Result<Patch<'_, str>>, usize) {
         Err(e) => return (Err(e), parser.offset()),
     };
 
-    let patch = Patch::new(
-        header.0.map(convert_cow_to_str),
-        header.1.map(convert_cow_to_str),
-        hunks,
-    );
-    (Ok(patch), parser.offset())
+    let original = match header.0.map(convert_cow_to_str).transpose() {
+        Ok(o) => o,
+        Err(e) => return (Err(e), parser.offset()),
+    };
+    let modified = match header.1.map(convert_cow_to_str).transpose() {
+        Ok(m) => m,
+        Err(e) => return (Err(e), parser.offset()),
+    };
+
+    (Ok(Patch::new(original, modified, hunks)), parser.offset())
 }
 
 pub fn parse_strict(input: &str) -> Result<Patch<'_, str>> {
@@ -113,10 +117,14 @@ pub fn parse_bytes_strict(input: &[u8]) -> Result<Patch<'_, [u8]>> {
 }
 
 // This is only used when the type originated as a utf8 string
-fn convert_cow_to_str(cow: Cow<'_, [u8]>) -> Cow<'_, str> {
+fn convert_cow_to_str(cow: Cow<'_, [u8]>) -> Result<Cow<'_, str>> {
     match cow {
-        Cow::Borrowed(b) => std::str::from_utf8(b).unwrap().into(),
-        Cow::Owned(o) => String::from_utf8(o).unwrap().into(),
+        Cow::Borrowed(b) => std::str::from_utf8(b)
+            .map(Cow::Borrowed)
+            .map_err(|_| ParsePatchErrorKind::InvalidUtf8Path.into()),
+        Cow::Owned(o) => String::from_utf8(o)
+            .map(Cow::Owned)
+            .map_err(|_| ParsePatchErrorKind::InvalidUtf8Path.into()),
     }
 }
 

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -90,6 +90,11 @@ impl<'a, T: Text + ?Sized> Parser<'a, T> {
     }
 }
 
+// TODO: make a better API for lib consumers
+//
+// Too many different variants of `parse*` functions here.
+// And that also propogate to `Patch::from_{str,bytes}{,_strict}`.
+
 pub fn parse(input: &str) -> Result<Patch<'_, str>> {
     let (result, _consumed) = parse_one(input, ParseOpts::default());
     result

--- a/src/patch/tests.rs
+++ b/src/patch/tests.rs
@@ -619,14 +619,10 @@ fn plain_filename_roundtrip() {
 }
 
 // Octal escape \377 decodes to 0xFF, which is not valid UTF-8.
-// When parsing into `Patch<'_, str>`, `convert_cow_to_str` panics
-// via `unwrap()` instead of returning a parse error.
-//
-// This documents the pre-existing bug that the reviewer flagged:
-// https://github.com/bmwill/diffy/pull/59#r3089024322
+// When parsing into `Patch<'_, str>`, this returns a parse error
+// instead of panicking.
 #[test]
-#[should_panic]
-fn non_utf8_escaped_filename_panics_on_str_parse() {
+fn non_utf8_escaped_filename_returns_error_on_str_parse() {
     let s = r#"\
 --- "a/foo\377"
 +++ "b/foo\377"
@@ -634,7 +630,10 @@ fn non_utf8_escaped_filename_panics_on_str_parse() {
 -x
 +y
 "#;
-    let _ = parse(s);
+    assert_eq!(
+        parse(s).unwrap_err().kind,
+        ParsePatchErrorKind::InvalidUtf8Path,
+    );
 }
 
 mod error_display {

--- a/src/patch/tests.rs
+++ b/src/patch/tests.rs
@@ -618,6 +618,25 @@ fn plain_filename_roundtrip() {
     assert_eq!(p.modified(), p2.modified());
 }
 
+// Octal escape \377 decodes to 0xFF, which is not valid UTF-8.
+// When parsing into `Patch<'_, str>`, `convert_cow_to_str` panics
+// via `unwrap()` instead of returning a parse error.
+//
+// This documents the pre-existing bug that the reviewer flagged:
+// https://github.com/bmwill/diffy/pull/59#r3089024322
+#[test]
+#[should_panic]
+fn non_utf8_escaped_filename_panics_on_str_parse() {
+    let s = r#"\
+--- "a/foo\377"
++++ "b/foo\377"
+@@ -1 +1 @@
+-x
++y
+"#;
+    let _ = parse(s);
+}
+
 mod error_display {
     use crate::patch::error::ParsePatchErrorKind;
     use crate::Patch;

--- a/src/patch_set/parse.rs
+++ b/src/patch_set/parse.rs
@@ -83,7 +83,8 @@ impl<'a> PatchSet<'a> {
 
         let patch_input = &remaining[patch_start..];
 
-        let (result, consumed) = parse_one(patch_input);
+        let opts = crate::patch::parse::ParseOpts::default();
+        let (result, consumed) = parse_one(patch_input, opts);
         // Always advance so the iterator makes progress even on error.
         let abs_patch_start = self.offset + patch_start;
         self.offset += patch_start + consumed;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -132,7 +132,7 @@ impl<'a, T: Text + ?Sized> Iterator for LineIter<'a, T> {
 
 /// A helper trait for processing text like `str` and `[u8]`
 /// Useful for abstracting over those types for parsing as well as breaking input into lines
-pub trait Text: Eq + Hash {
+pub trait Text: Eq + Hash + ToOwned {
     fn is_empty(&self) -> bool;
     fn len(&self) -> usize;
     fn starts_with(&self, prefix: &str) -> bool;
@@ -148,6 +148,12 @@ pub trait Text: Eq + Hash {
     #[allow(unused)]
     fn lines(&self) -> LineIter<'_, Self>;
 
+    /// Converts raw bytes into `Self::Owned`.
+    ///
+    /// Returns `None` if the bytes are not valid for this type
+    /// (e.g. non-UTF-8 bytes for `str`).
+    fn owned_from_bytes(bytes: Vec<u8>) -> Option<Self::Owned>;
+
     fn parse<T: std::str::FromStr>(&self) -> Option<T> {
         self.as_str().and_then(|s| s.parse().ok())
     }
@@ -156,6 +162,10 @@ pub trait Text: Eq + Hash {
 impl Text for str {
     fn is_empty(&self) -> bool {
         self.is_empty()
+    }
+
+    fn owned_from_bytes(bytes: Vec<u8>) -> Option<String> {
+        String::from_utf8(bytes).ok()
     }
 
     fn len(&self) -> usize {
@@ -207,6 +217,10 @@ impl Text for str {
 impl Text for [u8] {
     fn is_empty(&self) -> bool {
         self.is_empty()
+    }
+
+    fn owned_from_bytes(bytes: Vec<u8>) -> Option<Vec<u8>> {
+        Some(bytes)
     }
 
     fn len(&self) -> usize {
@@ -292,27 +306,29 @@ fn find_byte(haystack: &[u8], byte: u8) -> Option<usize> {
 ///
 /// See [`byte_needs_quoting`] for the set of characters that
 /// require quoting.
-pub(crate) fn escaped_filename<T: Text + ToOwned + ?Sized>(
+pub(crate) fn escaped_filename<T: Text + ?Sized>(
     filename: &T,
-) -> Result<Cow<'_, [u8]>, ParsePatchError> {
+) -> Result<Cow<'_, T>, ParsePatchError> {
     if let Some(inner) = filename
         .strip_prefix("\"")
         .and_then(|s| s.strip_suffix("\""))
     {
-        decode_escaped(inner)
+        match decode_escaped(inner.as_bytes())? {
+            None => Ok(Cow::Borrowed(inner)),
+            Some(bytes) => T::owned_from_bytes(bytes)
+                .map(Cow::Owned)
+                .ok_or_else(|| ParsePatchErrorKind::InvalidUtf8Path.into()),
+        }
     } else {
         let bytes = filename.as_bytes();
         if bytes.iter().any(|b| byte_needs_quoting(*b)) {
             return Err(ParsePatchErrorKind::InvalidCharInUnquotedFilename.into());
         }
-        Ok(bytes.into())
+        Ok(Cow::Borrowed(filename))
     }
 }
 
-fn decode_escaped<T: Text + ToOwned + ?Sized>(
-    escaped: &T,
-) -> Result<Cow<'_, [u8]>, ParsePatchError> {
-    let bytes = escaped.as_bytes();
+fn decode_escaped(bytes: &[u8]) -> Result<Option<Vec<u8>>, ParsePatchError> {
     let mut result = Vec::new();
     let mut i = 0;
     let mut last_copy = 0;
@@ -365,8 +381,8 @@ fn decode_escaped<T: Text + ToOwned + ?Sized>(
 
     if needs_allocation {
         result.extend_from_slice(&bytes[last_copy..]);
-        Ok(Cow::Owned(result))
+        Ok(Some(result))
     } else {
-        Ok(Cow::Borrowed(bytes))
+        Ok(None)
     }
 }


### PR DESCRIPTION
This is unfortunate we doesn't support non-UTF8 filename with `Patch<'_, str>` type (pre-existing btw).

This is a spin-off of refactors in #59, and addresses

* https://github.com/bmwill/diffy/pull/59/changes#r3088954435
* https://github.com/bmwill/diffy/pull/59/changes#r3089024322


