### PR TITLE
chore: `-Zrustdoc-scrape-examples` for rustdoc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ rustdoc-args = [
     # https://github.com/rust-lang/rust/pull/84176
     "-Zunstable-options", "--generate-link-to-definition"
 ]
+cargo-args = [
+    "-Zrustdoc-scrape-examples"
+]
 
 [features]
 default = []
@@ -43,6 +46,7 @@ snapbox = { version = "0.6.24", features = ["dir"] }
 [[example]]
 name = "patch_formatter"
 required-features = ["std", "color"]
+doc-scrape-examples = true
 
 [[test]]
 name = "compat"

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ check-no-std: ## Verify crate builds in no_std env
 
 .PHONY: doc
 doc: ## Generate documentation
-	RUSTDOCFLAGS="-Dwarnings --cfg=docsrs -Zunstable-options --generate-link-to-definition" RUSTC_BOOTSTRAP=1 cargo doc --all-features --no-deps
+	RUSTDOCFLAGS="-Dwarnings --cfg=docsrs -Zunstable-options --generate-link-to-definition" RUSTC_BOOTSTRAP=1 cargo doc --all-features --no-deps -Zrustdoc-scrape-examples
 
 .PHONY: doc-open
 doc-open: ## Generate and open documentation
-	RUSTDOCFLAGS="--cfg=docsrs -Zunstable-options --generate-link-to-definition" RUSTC_BOOTSTRAP=1 cargo doc --all-features --no-deps --open
+	RUSTDOCFLAGS="--cfg=docsrs -Zunstable-options --generate-link-to-definition" RUSTC_BOOTSTRAP=1 cargo doc --all-features --no-deps --open -Zrustdoc-scrape-examples
 
 .PHONY: is-dirty
 is-dirty: ## Checks if repository is dirty


### PR DESCRIPTION
See <https://doc.rust-lang.org/nightly/cargo/reference/unstable.htm#scrape-examples>

Part of <https://github.com/bmwill/diffy/issues/68>