### PR TITLE
fix(patch_set): multi-byte char boundary panic

### DIFF
--- a/src/patch_set/parse.rs
+++ b/src/patch_set/parse.rs
@@ -698,30 +698,42 @@ fn longest_common_path_suffix<'a, T: Text + ?Sized>(a: &'a T, b: &T) -> Option<&
         return None;
     }
 
-    let suffix_len = a
+    let mut last_slash = None;
+    let mut matched = 0;
+
+    for (i, (x, y)) in a
         .as_bytes()
         .iter()
         .rev()
         .zip(b.as_bytes().iter().rev())
-        .take_while(|(x, y)| x == y)
-        .count();
+        .enumerate()
+    {
+        if x != y {
+            break;
+        }
+        // `/` is ASCII,
+        // so this index is always a valid split point UTF-8 strings.
+        // No char boundary check needed.
+        if *x == b'/' {
+            last_slash = Some(i + 1);
+        }
+        matched = i + 1;
+    }
 
-    if suffix_len == 0 {
+    if matched == 0 {
         return None;
     }
 
     // Identical strings
-    if suffix_len == a.len() && a.len() == b.len() {
+    if matched == a.len() && a.len() == b.len() {
         return Some(a);
     }
 
-    // Find first '/' in suffix and return path after it
-    let suffix_start = a.len() - suffix_len;
-    let (_, suffix) = a.split_at(suffix_start);
-    suffix
-        .split_at_exclusive("/")
-        .map(|(_, path)| path)
-        .filter(|p| !p.is_empty())
+    // Return the path after the outermost `/` in the common suffix.
+    let suffix_len = last_slash?;
+    let start = a.len() - suffix_len + 1; // skip the '/'
+    let (_, path) = a.split_at(start);
+    (!path.is_empty()).then_some(path)
 }
 
 /// Extracts the file operation for a binary patch from git headers.

--- a/src/patch_set/tests.rs
+++ b/src/patch_set/tests.rs
@@ -479,6 +479,19 @@ mod patchset_gitdiff {
             .unwrap()
     }
 
+    /// Paths sharing trailing UTF-8 continuation bytes
+    /// but belonging to different codepoints must not panic
+    #[test]
+    #[should_panic(expected = "not a char boundary")]
+    fn multibyte_char_boundary_in_diff_git_path() {
+        // U+00BF INVERTED QUESTION MARK (¿) = 0xC2 0xBF
+        // U+00FF LATIN SMALL LETTER Y WITH DIAERESIS (ÿ) = 0xC3 0xBF
+        // Both share trailing byte 0xBF.
+        let input = "diff --git a/\u{bf} b/\u{ff}\n";
+        let _ = PatchSet::parse(input, ParseOptions::gitdiff())
+            .collect::<Result<Vec<_>, _>>();
+    }
+
     /// `parse_one` must stop at `diff --git` boundaries so that
     /// back-to-back patches are split correctly.
     /// Without this, the second patch's `diff --git` line would be

--- a/src/patch_set/tests.rs
+++ b/src/patch_set/tests.rs
@@ -482,14 +482,16 @@ mod patchset_gitdiff {
     /// Paths sharing trailing UTF-8 continuation bytes
     /// but belonging to different codepoints must not panic
     #[test]
-    #[should_panic(expected = "not a char boundary")]
     fn multibyte_char_boundary_in_diff_git_path() {
         // U+00BF INVERTED QUESTION MARK (¿) = 0xC2 0xBF
         // U+00FF LATIN SMALL LETTER Y WITH DIAERESIS (ÿ) = 0xC3 0xBF
         // Both share trailing byte 0xBF.
         let input = "diff --git a/\u{bf} b/\u{ff}\n";
-        let _ = PatchSet::parse(input, ParseOptions::gitdiff())
-            .collect::<Result<Vec<_>, _>>();
+        let result: Result<Vec<_>, _> = PatchSet::parse(input, ParseOptions::gitdiff()).collect();
+        assert_eq!(
+            result.unwrap_err().kind,
+            PatchSetParseErrorKind::InvalidDiffGitPath
+        );
     }
 
     /// `parse_one` must stop at `diff --git` boundaries so that


### PR DESCRIPTION
The old byte-level reverse cmp could produce a suffix offset
inside a multi-byte UTF-8 character and panic.

Rewrite to track `/` positions during the reverse scan
and only split at those.
(`/` is ASCII so no boundary check needed)

Found in fuzz test:
https://github.com/bmwill/diffy/actions/runs/24646265693/job/72059428553?pr=72