### PR TITLE
fix(patch): hunk range overflow panic 

### DIFF
--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -273,7 +273,7 @@ fn hunk_header<T: Text + ?Sized>(input: &T) -> Result<(HunkRange, HunkRange, Opt
 }
 
 fn range<T: Text + ?Sized>(s: &T) -> Result<HunkRange> {
-    let (start, len) = if let Some((start, len)) = s.split_at_exclusive(",") {
+    let (start, len): (usize, usize) = if let Some((start, len)) = s.split_at_exclusive(",") {
         (
             start.parse().ok_or(ParsePatchErrorKind::InvalidRange)?,
             len.parse().ok_or(ParsePatchErrorKind::InvalidRange)?,
@@ -281,6 +281,11 @@ fn range<T: Text + ?Sized>(s: &T) -> Result<HunkRange> {
     } else {
         (s.parse().ok_or(ParsePatchErrorKind::InvalidRange)?, 1)
     };
+
+    // reject ranges that overflow
+    start
+        .checked_add(len)
+        .ok_or(ParsePatchErrorKind::InvalidRange)?;
 
     Ok(HunkRange::new(start, len))
 }

--- a/src/patch/tests.rs
+++ b/src/patch/tests.rs
@@ -639,7 +639,6 @@ fn non_utf8_escaped_filename_returns_error_on_str_parse() {
 }
 
 #[test]
-#[should_panic = "attempt to add with overflow"]
 fn hunk_range_overflow() {
     let s = format!(
         "\
@@ -651,8 +650,10 @@ fn hunk_range_overflow() {
 ",
         usize::MAX,
     );
-    let patch = crate::Patch::from_str(&s).unwrap();
-    let _ = patch.hunks()[0].old_range().end();
+    assert_eq!(
+        crate::Patch::from_str(&s).unwrap_err().kind,
+        ParsePatchErrorKind::InvalidRange,
+    );
 }
 
 mod error_display {

--- a/src/patch/tests.rs
+++ b/src/patch/tests.rs
@@ -638,6 +638,23 @@ fn non_utf8_escaped_filename_returns_error_on_str_parse() {
     );
 }
 
+#[test]
+#[should_panic = "attempt to add with overflow"]
+fn hunk_range_overflow() {
+    let s = format!(
+        "\
+--- a/file.txt
++++ b/file.txt
+@@ -{},1 +1 @@
+-old
++new
+",
+        usize::MAX,
+    );
+    let patch = crate::Patch::from_str(&s).unwrap();
+    let _ = patch.hunks()[0].old_range().end();
+}
+
 mod error_display {
     use alloc::string::ToString;
 


### PR DESCRIPTION
This fix was chosen becuase it is the minimal one.

The other two call sites are not affected, as the comes from slices, where the length is bound by `isize::MAX` IIUC: <https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety>.

Alternatively we can return an `Option` from `HunkRange::new`.

See

* <https://github.com/bmwill/diffy/actions/runs/24816232096/job/72631143909>
* <https://github.com/bmwill/diffy/issues/69#issuecomment-4290986913>