### PR TITLE
merge: keep conflict markers on their own lines when hunks lack a trailing newline

### DIFF
--- a/src/merge/mod.rs
+++ b/src/merge/mod.rs
@@ -604,6 +604,9 @@ fn add_conflict_marker(
     marker_len: usize,
     filename: Option<&str>,
 ) {
+    if !output.is_empty() && !output.ends_with('\n') {
+        output.push('\n');
+    }
     for _ in 0..marker_len {
         output.push(marker);
     }
@@ -684,6 +687,9 @@ fn add_conflict_marker_bytes(
     marker_len: usize,
     filename: Option<&[u8]>,
 ) {
+    if !output.is_empty() && output.last() != Some(&b'\n') {
+        output.push(b'\n');
+    }
     for _ in 0..marker_len {
         output.push(marker);
     }

--- a/src/merge/tests.rs
+++ b/src/merge/tests.rs
@@ -404,3 +404,29 @@ fn delete_and_insert_conflict() {
         "MergeRange (Theirs::delete, Ours::insert) conflict"
     );
 }
+
+#[test]
+fn conflict_hunks_without_trailing_newline_keep_markers_on_own_lines() {
+    let base = "This is line 1.\nThis is line 2.";
+    let ours = "This is line 1.\nThis is line 2 changed.";
+    let theirs = "This is line 1.\nThis is line 2 also changed.";
+
+    let expected = "\
+This is line 1.
+<<<<<<< ours
+This is line 2 changed.
+||||||| original
+This is line 2.
+=======
+This is line 2 also changed.
+>>>>>>> theirs
+";
+
+    assert_merge!(
+        base,
+        ours,
+        theirs,
+        Err(expected),
+        "file-final hunks without trailing newline",
+    );
+}


### PR DESCRIPTION
When a conflicting hunk sits at end-of-file without a trailing newline, `merge`/`merge_bytes`
glue the next conflict marker onto the content line, producing unparseable output:

```
    base:   "This is line 1.\nThis is line 2."
    ours:   "This is line 1.\nThis is line 2 changed."
    theirs: "This is line 1.\nThis is line 2 also changed."
```

Actual:

```
    This is line 1.
    <<<<<<< ours
    This is line 2 changed.||||||| original
    This is line 2.=======
    This is line 2 also changed.>>>>>>> theirs
```

Expected (matches `git merge-file --diff3` on identical inputs):

```
    This is line 1.
    <<<<<<< ours
    This is line 2 changed.
    ||||||| original
    This is line 2.
    =======
    This is line 2 also changed.
    >>>>>>> theirs
```

`add_conflict_marker`/`add_conflict_marker_bytes` now prefix a newline when the output
doesn't already end with one. Only reachable for file-final hunks, so all existing merge
output is unchanged — the full suite passes untouched. One new test covers both the str
and bytes paths via `assert_merge!`.