### PR TITLE
fix(patch): accept CRLF line endings in the ---/+++ headers

### DIFF
--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -181,7 +181,11 @@ fn parse_filename<'a, T: Text + ?Sized>(prefix: &str, line: &'a T) -> Result<Cow
     let filename = if let Some((filename, _)) = line.split_at_exclusive("\t") {
         filename
     } else if let Some((filename, _)) = line.split_at_exclusive("\n") {
-        filename
+        // Accept CRLF line endings, as produced by tools on Windows.
+        // A carriage return is never part of the filename itself: it has
+        // to be quoted when unquoted filenames are used, and is written
+        // as the `\r` escape inside a quoted one. See `byte_needs_quoting`.
+        filename.strip_suffix("\r").unwrap_or(filename)
     } else {
         return Err(ParsePatchErrorKind::FilenameUnterminated.into());
     };

--- a/src/patch/tests.rs
+++ b/src/patch/tests.rs
@@ -638,6 +638,101 @@ fn non_utf8_escaped_filename_returns_error_on_str_parse() {
     );
 }
 
+// Patches produced on Windows terminate their header lines with CRLF.
+// The carriage return belongs to the line ending, not to the filename.
+#[test]
+fn crlf_patch_header() {
+    let s = "\
+--- original\r
++++ modified\r
+@@ -1,2 +1,3 @@\r
+ Allomancy\r
+ Feruchemy\r
++Hemalurgy\r
+";
+    let p = parse(s).unwrap();
+    assert_eq!(p.original(), Some("original"));
+    assert_eq!(p.modified(), Some("modified"));
+    assert_eq!(p.hunks().len(), 1);
+
+    let b = parse_bytes(s.as_ref()).unwrap();
+    assert_eq!(b.original(), Some(&b"original"[..]));
+    assert_eq!(b.modified(), Some(&b"modified"[..]));
+
+    // The same patch with LF line endings yields the same filenames.
+    let lf = "\
+--- original
++++ modified
+@@ -1,2 +1,3 @@
+ Allomancy
+ Feruchemy
++Hemalurgy
+";
+    let lf = parse(lf).unwrap();
+    assert_eq!(p.original(), lf.original());
+    assert_eq!(p.modified(), lf.modified());
+}
+
+// A timestamp is separated from the filename by a tab, so the carriage
+// return of a CRLF ending trails the timestamp rather than the filename.
+#[test]
+fn crlf_patch_header_with_timestamp() {
+    let s = "\
+--- original\t2022-10-18 22:41:24.000000000 +0000\r
++++ modified\t2022-10-18 22:41:24.000000000 +0000\r
+@@ -1,0 +1,1 @@\r
++Oathbringer\r
+";
+    let p = parse(s).unwrap();
+    assert_eq!(p.original(), Some("original"));
+    assert_eq!(p.modified(), Some("modified"));
+}
+
+// Quoted filenames escape a carriage return as `\r`, so the only raw
+// carriage return on the line is the one from the line ending.
+#[test]
+fn crlf_patch_header_quoted_filename() {
+    let s = "\
+--- \"ori\\rginal\"\r
++++ \"mo\\rdified\"\r
+@@ -1,0 +1,1 @@\r
++Oathbringer\r
+";
+    let p = parse(s).unwrap();
+    assert_eq!(p.original(), Some("ori\rginal"));
+    assert_eq!(p.modified(), Some("mo\rdified"));
+}
+
+// A carriage return that isn't part of the line ending still has to be
+// quoted, exactly as before.
+#[test]
+fn unquoted_carriage_return_in_filename_still_rejected() {
+    let s = "\
+--- ori\rginal
++++ modified
+@@ -1,0 +1,1 @@
++Oathbringer
+";
+    assert_eq!(
+        parse(s).unwrap_err().kind,
+        ParsePatchErrorKind::InvalidCharInUnquotedFilename,
+    );
+    parse_bytes(s.as_ref()).unwrap_err();
+
+    // Same, with CRLF line endings.
+    let s = "\
+--- ori\rginal\r
++++ modified\r
+@@ -1,0 +1,1 @@\r
++Oathbringer\r
+";
+    assert_eq!(
+        parse(s).unwrap_err().kind,
+        ParsePatchErrorKind::InvalidCharInUnquotedFilename,
+    );
+    parse_bytes(s.as_ref()).unwrap_err();
+}
+
 #[test]
 fn hunk_range_overflow() {
     let s = format!(


### PR DESCRIPTION
Addresses the first half of #20: parsing a patch with CRLF line endings.

## The bug

`LineIter` hands `parse_filename` a whole line including its terminator, and
`parse_filename` splits the filename off at `\t` or `\n`. When the patch uses
CRLF endings there is no tab and the split at `\n` leaves the carriage return
attached to the filename. `escaped_filename` then rejects it, because a raw
control byte is not allowed in an unquoted filename.

The result is that any unified diff generated on Windows fails to parse:

```rust
let patch_lf   = "--- original\n+++ modified\n@@ -1,2 +1,3 @@\n Allomancy\n Feruchemy\n+Hemalurgy\n";
let patch_crlf = "--- original\r\n+++ modified\r\n@@ -1,2 +1,3 @@\r\n Allomancy\r\n Feruchemy\r\n+Hemalurgy\r\n";

Patch::from_str(patch_lf);   // Ok
Patch::from_str(patch_crlf); // Err(ParsePatchError { kind: InvalidCharInUnquotedFilename, .. })
```

Everything else in the parser already copes with CRLF: the hunk header's
function-context split leaves the `\r\n` in the unused tail, and hunk content
lines keep their line endings verbatim. The filename header is the only thing
in the way.

## The fix

Strip a single trailing carriage return from the filename field when it was
terminated by `\n`.

This is unambiguous rather than a heuristic. A raw carriage return can never
be part of a filename as written in a patch: `byte_needs_quoting` rejects it in
an unquoted filename, and a quoted filename encodes it as the two-character
`\r` escape. So a raw `\r` immediately before the line terminator is always the
line ending. A carriage return anywhere else on the line is still rejected with
`InvalidCharInUnquotedFilename`, and the tab-terminated form (`--- file\t<timestamp>`)
is untouched, since there the carriage return trails the timestamp.

The same reasoning is already applied elsewhere in the crate — the binary patch
parser strips a trailing `\r` off each line for exactly this reason.

## Verification

Four tests added in `src/patch/tests.rs`, covering both `parse` and `parse_bytes`:
a CRLF header, a CRLF header with a timestamp, a CRLF header with quoted
filenames, and a filename with a carriage return in the middle, which must still
be rejected. The CRLF tests also assert that the LF form of the same patch yields
identical filenames, so this cannot silently change LF behaviour.

Before the change:

```
running 5 tests
test binary::tests::parse_with_crlf_line_endings ... ok
test binary::apply_tests::apply_with_crlf_line_endings ... ok
test patch::tests::crlf_patch_header_with_timestamp ... ok
test patch::tests::crlf_patch_header_quoted_filename ... FAILED
test patch::tests::crlf_patch_header ... FAILED

---- patch::tests::crlf_patch_header stdout ----
called `Result::unwrap()` on an `Err` value: ParsePatchError { kind: InvalidCharInUnquotedFilename, span: None }
```

After:

```
running 3 tests
test patch::tests::crlf_patch_header_with_timestamp ... ok
test patch::tests::crlf_patch_header_quoted_filename ... ok
test patch::tests::crlf_patch_header ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 124 filtered out
```

Full suite with `--all-features`: 127 unit (was 123), 52 compat, 20 doc, all
passing. `make check-fmt` and `make clippy` with `RUSTFLAGS=-D warnings` are
clean, and the crate still builds with `--no-default-features`.

The change touches no feature-gated or `std`-only code, and the fuzz targets are
unaffected in kind — `patch_from_str`/`patch_from_bytes` only assert absence of
panics, and this only widens the set of inputs that reach `Ok`.

This also gets you the case from the issue thread that you pointed at as the
useful outcome — patching a CRLF file with a CRLF patch:

```
original=Some("original") modified=Some("modified")
applied=Ok("Allomancy\r\nFeruchemy\r\nHemalurgy\r\n")
```

## Deliberately not changed

Per your triage on the issue, this only covers the header parsing half. Applying
a patch whose line endings differ from the text being patched
(`diffy::apply(text_crlf, &p_lf)`) is left alone — that needs a decision about
fuzzy matching and mixed-ending output that is well beyond this change, so #20
stays open.

Also untouched: `PatchSet`'s `strip_line_ending` (`src/patch_set/parse.rs`), which
strips only `\n` and already carries a TODO about CRLF and GNU patch compat. The
git extended headers (`rename from`, `copy to`, `diff --git`) go through it, so
they have the same sensitivity. That felt like a separate change with its own
compat-test story; happy to follow up if you want it.

Credit to @Qyriad for the report and the reproducer, and to your comment on the
issue for scoping the fix to the header parsing logic.
